### PR TITLE
Disable autocomplete on password field

### DIFF
--- a/datasette_auth_passwords/templates/password_tool.html
+++ b/datasette_auth_passwords/templates/password_tool.html
@@ -45,7 +45,7 @@ button.copy-hashed-password {
 
 <form action="/-/password-tool" method="post">
     <div>
-        <input type="text" name="password" style="width: 40%">
+        <input type="text" name="password" style="width: 40%" autocomplete="off">
         <input type="hidden" name="csrftoken" value="{{ csrftoken() }}">
         <input type="submit" value="Create password hash">
     </div>


### PR DESCRIPTION
Autocomplete should be disabled so that all the user's passwords aren't kept in the autocomplete cache. I could also see an argument for this even being a `new-password` field, but it can be helpful to see the password.